### PR TITLE
qorc_tc_path_corrections

### DIFF
--- a/qf_pm2dot5aqi/GCC_Project/Readme.txt
+++ b/qf_pm2dot5aqi/GCC_Project/Readme.txt
@@ -20,7 +20,7 @@ The following is a brief description of Makefile Architecture used for QuickAI S
       -set BUILD_SYS=WINCMD - for Windows or comment it out for Linux
       Note: 
         On Windows 10, there may be a problem to "auto-detect" the ARM Gnu Embedded Tool
-        Chain path. Then explicit set the TC_PATH to where the ARM GCC tools are installed.
+        Chain path. Then explicit set the QORC_TC_PATH to where the ARM GCC tools are installed.
       -
     2. config-GCC.mk - sets the GCC compiler options, source directories and "output file"
     
@@ -51,7 +51,7 @@ Adding New makefiles:
        - create build commands for the new Target as .PHONY objects point to your new makefile
 
 Building:
-     Make sure "C:\GnuWin32\bin" is the first in the Path and TC_PATH is properly set.
+     Make sure "C:\GnuWin32\bin" is the first in the Path and QORC_TC_PATH is properly set.
      - At the command prompt just type "make" to build all
      - Type "make clean" to delete all the object files and output built
      - type "make target" to selectively build a Target (for example, "make HAL")

--- a/qf_pm2dot5aqi/GCC_Project/config.mk
+++ b/qf_pm2dot5aqi/GCC_Project/config.mk
@@ -96,28 +96,30 @@ TMPVAR = $(subst \, ,${APP_DIR})
 PROJ_NAME=$(word $(words ${TMPVAR}),${TMPVAR})
 export PROJ_NAME
 
+ifndef QORC_TC_PATH
 FIND_TOOL_DIR := $(shell where arm-none-eabi-gcc)
 ifndef FIND_TOOL_DIR
 $(info using recursive search)
 FIND_TOOL_DIR := $(shell where /r c:\progra~2 arm-none-eabi-gcc)
 endif
+endif #QORC_TC_PATH
 
 ifdef FIND_TOOL_DIR
-export TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
+export QORC_TC_PATH = $(subst \arm-none-eabi-gcc.exe,,$(FIND_TOOL_DIR))
 endif
 
 #Override with your own tool direcoty
-#export TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+#export QORC_TC_PATH=C:\Program Files (x86)\GNU Tools ARM Embedded\7 2017-q4-major\bin
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
 
-export NM="$(TC_PATH)\arm-none-eabi-nm"
-export LD="$(TC_PATH)\arm-none-eabi-gcc"
-export AS="$(TC_PATH)\arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)\arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)\arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)\arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)\arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)\arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)\arm-none-eabi-objcopy"
 ################
 else
 ################ Linux ###################
@@ -149,25 +151,25 @@ export QORC_TC_PATH = $(subst /arm-none-eabi-gcc,,$(FIND_TOOL_DIR))
 endif #QORC_TC_PATH
 
 # Allow TOOL to be provided on the command line
-# ie;   make -f Makefile TC_PATH=/some/path/
+# ie;   make -f Makefile QORC_TC_PATH=/some/path/
 
-ifndef TC_PATH
+ifndef QORC_TC_PATH
 #Override with your own tool directory
 #use full path. do not use ~/ as a relative path
-#export TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
-#export TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
-export TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
+#export QORC_TC_PATH="~/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin"  <<<=== will not work
+#export QORC_TC_PATH="/home/user_name/arm-gnu/gcc-arm-none-eabi-7-2017-q4-major/bin" <<<=== works
+#export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin
 endif
 
-ifndef TC_PATH
-$(info ######  ERROR - TC_PATH is not defined in config.mk #########)
+ifndef QORC_TC_PATH
+$(info ######  ERROR - QORC_TC_PATH is not defined in config.mk #########)
 exit
 endif
-export NM="$(TC_PATH)/arm-none-eabi-nm"
-export LD="$(TC_PATH)/arm-none-eabi-gcc"
-export AS="$(TC_PATH)/arm-none-eabi-gcc" -c
-export CC="$(TC_PATH)/arm-none-eabi-gcc" -c
-export ELF2BIN="$(TC_PATH)/arm-none-eabi-objcopy"
+export NM="$(QORC_TC_PATH)/arm-none-eabi-nm"
+export LD="$(QORC_TC_PATH)/arm-none-eabi-gcc"
+export AS="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export CC="$(QORC_TC_PATH)/arm-none-eabi-gcc" -c
+export ELF2BIN="$(QORC_TC_PATH)/arm-none-eabi-objcopy"
 ################
 endif
 ################


### PR DESCRIPTION
There are a couple of places where the multi-compiler-fix has rough edges, this PR aims to fix those:

1. Left Over ```TC_PATH``` instances
    Remaining ```TC_PATH``` references changed to ```QORC_TC_PATH```

2. Windows Makefile Part (like the Linux Makefile Part)
    ```FIND_TOOL_DIR := $(shell where arm-none-eabi-gcc)``` should be wrapped by ```ifndef QORC_TC_PATH```

3. In the Linux Makefile Part
    ```export QORC_TC_PATH=/usr/local/gcc-arm-none-eabi-7-2017-q4-major/bin``` should be commented out as a default option.
   This should be used by users, if they want to explicitly hardcode this in the makefile (which is now not needed anyway)